### PR TITLE
fix(logger): files needs to migrated from Tape to Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/invoke-contract-xdai-json-object.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
-    `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts`,
     `./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts`,
     `./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts`,

--- a/packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
@@ -1,66 +1,46 @@
-import test, { Test } from "tape";
 import { v4 as uuidv4 } from "uuid";
 import { LoggerProvider } from "../../../../main/typescript/public-api";
 
-// FIXME(2020-11-12) this does not work because for some reason the stdout
-// stream does not emit 'data' events with anything even though it should.
-// Suspecting that the test runner library does some internal magic with
-// piping the stream somewhere else or similar foul play at hand.
-// Until we can fix this, marked the test to be skipped.
-test.skip("Logger#debug/error writes to stdout/stderr", async (t: Test) => {
-  const log = LoggerProvider.getOrCreate({
-    level: "TRACE",
-    label: "logger-test",
-  });
-
-  // generate random UUID v4 to guarantee we don't mistake something else as the marker
-  const marker = uuidv4();
-  interface DataHandler {
-    (data: Buffer): void;
-  }
-  // wait for the marker to appear on stdout OR crash with timeout if it never comes
-  let aggregateStdOut = "";
-  let stdOutDataHandler: undefined | DataHandler;
-  let didNotThrow: boolean;
-
-  try {
-    // hook up to the stdout data stream and wrap it in a promise that can be awaited
-    // for when the marker does appear on stdout (which would be a passing test)
-    // or when it times out (which would mean the test is failing).
-    // Certain issues could happen here if the stream is chunking data and then you never
-    // actually get the complete marker string at once but instead different parts of it
-    // but I did not consider this because the uuid is only a few dozen bytes when stored as a hex string
-    // so I'm pretty confident it wouldn't get chunked (probably not impossible either though so
-    // if you are paranoid about that happening (which would make the test flaky) then you can
-    // bake in some stream data aggregation instead where you collect and continually append
-    // the incoming data chunks and test for marker presence in the aggregate variable not the chunk
-    // that is provided in the 'data' event handler callback.
-    await new Promise<void>((resolve, reject) => {
-      const timeoutMsg = "Timed out waiting for marker to appear on stdout";
-      const timerId = setTimeout(() => reject(new Error(timeoutMsg)), 5000);
-
-      const stdOutDataHandler: DataHandler = (data: Buffer) => {
-        const msg = data.toString("utf-8");
-        aggregateStdOut = aggregateStdOut.concat(msg);
-        if (msg.includes(marker)) {
-          clearInterval(timerId);
-          resolve();
-        }
-      };
-
-      process.stdout.on("data", stdOutDataHandler);
-
-      // send the log now that we have hooked into the stream waiting for the marker to appear
-      log.info(marker);
+describe("Logger Tests", () => {
+  it("Logger#debug/error writes to stdout/stderr", async () => {
+    const log = LoggerProvider.getOrCreate({
+      level: "TRACE",
+      label: "logger-test",
     });
-    didNotThrow = true;
-  } catch (ex) {
-    didNotThrow = false;
-  }
 
-  process.stdout.off("data", stdOutDataHandler as DataHandler);
-  t.comment(`Aggregate std out messages: ${aggregateStdOut}`);
-  t.true(didNotThrow, "Marker appeared on stdout on time OK");
+    // generate random UUID v4 to guarantee we don't mistake something else as the marker
+    const marker = uuidv4();
 
-  t.end();
+    // Capture original stdout write method
+    const originalWrite = process.stdout.write;
+    let outputData = "";
+
+    // Mock process.stdout.write to capture output
+    process.stdout.write = function (
+      chunk: any,
+      encoding?: any,
+      callback?: any,
+    ): boolean {
+      outputData += chunk.toString();
+      if (callback) callback();
+      return true;
+    };
+
+    try {
+      log.info(marker);
+
+      // Delay to ensure log output is flushed
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Restore original stdout.write
+      process.stdout.write = originalWrite;
+
+      // Check if the marker appeared in the captured output
+      expect(outputData).toContain(marker);
+      log.info(`Marker (${marker}) appeared in stdout OK`);
+    } catch (error) {
+      process.stdout.write = originalWrite; // Ensure restoration in case of errors
+      throw error;
+    }
+  });
 });


### PR DESCRIPTION
### Commit to be reviewed
---
fix(logger): files needs to migrated from Tape to Jest
```
Primary Changes
---------------
1. Fixed logger.test.ts after removing the skip on the test and UUID marker
now appears in the custom stream output
2. Migrated test file from tape to jest test
3. Removed file path of logger.test.ts in testPathIgnorePatterns to run jest
test
```

Fixes:

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.